### PR TITLE
fix: Include missing res argument

### DIFF
--- a/src/serve/routes/index.js
+++ b/src/serve/routes/index.js
@@ -77,7 +77,7 @@ export default function (router, context, options) {
       return
     }
 
-    sendFile(resolve(url))
+    sendFile(resolve(url), res)
   })
 
   console.log(`   ${chalk.blue('blog:api')} Listening on /${options.api.prefix}`)


### PR DESCRIPTION
## Issue: 
When clicking on a blog post, the router would fail to route to the correct endpoint, with an error `res is undefined`

## Fix:
This fix adds the missing res argument to a sendFile function